### PR TITLE
Add detection for all chapter lang is und and fix overriding bug

### DIFF
--- a/MediainfoProjectNg/Converter/ChapterLanguageToColorConverter.cs
+++ b/MediainfoProjectNg/Converter/ChapterLanguageToColorConverter.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 using System.Collections.Generic;
-using MediainfoProjectNg;
 
 namespace MediainfoProjectNg.Converter
 {
@@ -18,11 +17,14 @@ namespace MediainfoProjectNg.Converter
             if (value is not List<ChapterInfo> chapterInfos || chapterInfos.Count == 0)
                 return DependencyProperty.UnsetValue;
 
-            var firstLang = chapterInfos[0].Language ?? "";
-            bool allSame = chapterInfos.All(chap =>
-                string.Equals(chap.Language, firstLang, StringComparison.OrdinalIgnoreCase));
+            var chapterLanguages = chapterInfos
+                .Select(chap => chap.Language ?? "")
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
-            return allSame ? Binding.DoNothing : Brushes.Yellow;
+            bool hasLanguageIssues = chapterLanguages.Count > 1 || (chapterLanguages.Count == 1 && chapterLanguages[0] == "");
+
+            return hasLanguageIssues ? Brushes.Yellow : Binding.DoNothing;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/MediainfoProjectNg/Utils.cs
+++ b/MediainfoProjectNg/Utils.cs
@@ -263,23 +263,6 @@ namespace MediainfoProjectNg
                         ));
                     }
                 }
-                
-                if (info.GeneralInfo.ChapterCount > 0 && info.ChapterInfos.Any())
-                {
-                    var chapterLanguages = info.ChapterInfos
-                        .Select(chap => chap.Language ?? "")
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToList();
-
-                    if (chapterLanguages.Count > 1 || (chapterLanguages.Count == 1 && chapterLanguages[0] == ""))
-                    {
-                        ret.Add(new ErrorInfo(
-                            level:       ErrorLevel.Error,
-                            description: "章节语言存在问题。",
-                            brush:       SystemColors.WindowBrush
-                        ));
-                    }
-                }
 
                 if (!FileNameContentMatched(info))
                 {

--- a/MediainfoProjectNg/Utils.cs
+++ b/MediainfoProjectNg/Utils.cs
@@ -266,18 +266,16 @@ namespace MediainfoProjectNg
                 
                 if (info.GeneralInfo.ChapterCount > 0 && info.ChapterInfos.Any())
                 {
-                    var firstLang = info.ChapterInfos.First().Language ?? "";
+                    var chapterLanguages = info.ChapterInfos
+                        .Select(chap => chap.Language ?? "")
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
 
-                    var inconsistent = info.ChapterInfos
-                        .Skip(1)
-                        .Any(chap => !string.IsNullOrEmpty(chap.Language) &&
-                                    !chap.Language.Equals(firstLang, StringComparison.OrdinalIgnoreCase));
-
-                    if (inconsistent)
+                    if (chapterLanguages.Count > 1 || (chapterLanguages.Count == 1 && chapterLanguages[0] == ""))
                     {
                         ret.Add(new ErrorInfo(
                             level:       ErrorLevel.Error,
-                            description: "章节语言不一致。",
+                            description: "章节语言存在问题。",
                             brush:       SystemColors.WindowBrush
                         ));
                     }


### PR DESCRIPTION
- Added detection for when all chapter languages are "und" by using a deduplicated list.
- Found that removing chapter language detection logic from Utils.cs resolves the issue where chapter errors override other error messages.
